### PR TITLE
feat: fetch version information from ldflags

### DIFF
--- a/cmd/varnishncsa-exporter/varnishncsa-exporter.go
+++ b/cmd/varnishncsa-exporter/varnishncsa-exporter.go
@@ -12,13 +12,22 @@ import (
 	"github.com/criteo/varnishncsa-exporter/internal/config"
 	"github.com/criteo/varnishncsa-exporter/lib/command"
 	"github.com/criteo/varnishncsa-exporter/lib/prometheus"
-	"github.com/criteo/varnishncsa-exporter/lib/utils"
 	"github.com/julienschmidt/httprouter"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/urfave/cli/v2"
 
 	log "github.com/sirupsen/logrus"
 )
+
+var (
+	version = "unknown"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
+func versionGet() string {
+	return fmt.Sprintf("Version: %s - Commit: %s - Date: %s", version, commit, date)
+}
 
 func main() {
 	app := &cli.App{
@@ -107,7 +116,7 @@ func main() {
 		},
 		Action: func(ctx *cli.Context) error {
 			if ctx.Bool("version") {
-				return cli.Exit(utils.VersionGet(), 0)
+				return cli.Exit(versionGet(), 0)
 			}
 			if ctx.Bool("debug") {
 				log.SetLevel(log.DebugLevel)
@@ -127,6 +136,7 @@ func main() {
 
 			var wg sync.WaitGroup
 			wg.Add(1)
+			log.Info(versionGet())
 			go command.RunCommand(ctx.String("binary"), []string{"-n", ctx.String("directory"), "-F", ctx.String("format")}, counters, prometheusLabels, true, &wg)
 
 			httpAddressPort := fmt.Sprintf("%s:%d", ctx.String("httpd_address"), ctx.Int("httpd_port"))

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -1,7 +1,6 @@
 package config
 
 var (
-	Version            = "0.1"
 	Binary             = "/usr/bin/varnishncsa"
 	WorkingDir         = "/run/varnish/"
 	PrometheusLabels   = "{\"X-Real-Host\": \"host\", \"X-Frontend-Id\": \"frontend\"}"

--- a/lib/utils/version.go
+++ b/lib/utils/version.go
@@ -1,7 +1,0 @@
-package utils
-
-import "github.com/criteo/varnishncsa-exporter/internal/config"
-
-func VersionGet() string {
-	return config.Version
-}


### PR DESCRIPTION
<!-- Please respect the guidelines explained in CONTRIBUTING.md -->

**Description:**

Since we're using GoReleaser to package the application, implicitely use constant main.version, main.commit and main.date set as ldflags.

See https://goreleaser.com/cookbooks/using-main.version/