### PR TITLE
Bump go version + fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.22"
+        go-version: "1.23"
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,13 @@ jobs:
       - name: Install required dependencies
         run: |
           sudo apt install -y git curl
-          curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-          sudo DEBIAN_FRONTEND=noninteractive apt install -y nodejs
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/refs/heads/master/nvm.sh | bash
+          export NVM_DIR="$HOME/.nvm" \
+            && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
+            && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" \
+            && nvm install 20 \
+            && sudo ln -s $(which node) /usr/bin/node \
+            && sudo ln -s $(which npm) /usr/bin/npm
 
       - name: Install commitlint
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,15 @@ jobs:
     name: "Lint and test"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: "1.23"
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v4
 
     - name: Test
       run: go test -v ./...
@@ -30,7 +30,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install required dependencies

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -
@@ -22,7 +22,7 @@ jobs:
         run: git fetch --force --tags
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: "1.23"
       -

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -24,7 +24,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.22"
+          go-version: "1.23"
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/cmd/varnishncsa-exporter/varnishncsa-exporter.go
+++ b/cmd/varnishncsa-exporter/varnishncsa-exporter.go
@@ -81,7 +81,7 @@ func main() {
 					if address == "localhost" {
 						return nil
 					} else if net.ParseIP(address) == nil {
-						return fmt.Errorf(fmt.Sprintf("IP Address: %s - Invalid", address))
+						return fmt.Errorf("IP Address: %s - Invalid", address)
 					}
 					return nil
 				},
@@ -96,7 +96,7 @@ func main() {
 			&cli.IntFlag{
 				Action: func(ctx *cli.Context, port int) error {
 					if port < 1024 || port > 49151 {
-						return fmt.Errorf(fmt.Sprintf("Port: %d - Invalid - 1024 <= port <= 49151", port))
+						return fmt.Errorf("port: %d - Invalid - 1024 <= port <= 49151", port)
 					}
 					return nil
 				},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/criteo/varnishncsa-exporter
 
-go 1.22
+go 1.23
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0


### PR DESCRIPTION
- Bump to go 1.23
- Update versions on ci
- Enable manual triggering of ci job
- fix nodjs install